### PR TITLE
fix: update dependencies and add search parameter in 404 page

### DIFF
--- a/.changeset/true-dodos-stand.md
+++ b/.changeset/true-dodos-stand.md
@@ -1,0 +1,5 @@
+---
+"thulite-website": patch
+---
+
+fix: update dependencies and add search parameter in 404 page

--- a/content/404.md
+++ b/content/404.md
@@ -7,6 +7,7 @@ draft = false
 
 [params]
 sitemap = false
+search = false
 
 [params.seo]
 title = "" # custom title (optional)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.8.0",
       "license": "UNLICENSED",
       "dependencies": {
-        "@ventizo/atlas-core": "^0.1.3"
+        "@ventizo/atlas-core": "^0.1.4"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
@@ -2516,9 +2516,9 @@
       "license": "MIT"
     },
     "node_modules/@tabler/icons": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
-      "integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.45.0.tgz",
+      "integrity": "sha512-jiATwV8+zGYLTZ7gMLGivCic+KtsMZXcDmufIG8umlLxoHhI6902hGYIEt0Oa9Y9SXblNzUlrisHm5jOFMxOQA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2608,9 +2608,9 @@
       }
     },
     "node_modules/@ventizo/atlas-core": {
-      "version": "0.1.3",
-      "resolved": "https://npm.pkg.github.com/download/@ventizo/atlas-core/0.1.3/f17b7e12d429f61720fba212ba722c57e937cdb1",
-      "integrity": "sha512-HEe+llXBreipH8UXJjPpy3lHioH7FL0rfiP7+336mcjdhoXW73wsuxy4xj0WhQpUST3w/dL2Q8JgHsBakncE9Q==",
+      "version": "0.1.4",
+      "resolved": "https://npm.pkg.github.com/download/@ventizo/atlas-core/0.1.4/e908467f301c6b0dca48d4fae67069ef90cbc017",
+      "integrity": "sha512-QTObiSHa98w02TPS7znaVNmsHncAvdZ3090/dVVqtDhYDSqAun/hJZK7VCKl38zvuMmwIZj1HC68jKTebvFYNA==",
       "license": "UNLICENSED",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
@@ -3116,9 +3116,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.392",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
-      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preview": "vite preview --outDir public"
   },
   "dependencies": {
-    "@ventizo/atlas-core": "^0.1.3"
+    "@ventizo/atlas-core": "^0.1.4"
   },
   "overrides": {
     "minimatch": "^10.2.2",


### PR DESCRIPTION
This pull request includes a minor dependency update and a configuration change to the 404 page.

Dependency update:

* Updated `@ventizo/atlas-core` to version `^0.1.4` in `package.json` to ensure the project uses the latest features and fixes.

Configuration change:

* Added `search = false` to the `[params]` section in `content/404.md` to disable search functionality on the 404 page.